### PR TITLE
fix(security): harden contact form against spam abuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,3 +114,16 @@ MAX_DOCUMENT_SIZE=10
 TRANSLATION_PROVIDER=libretranslate
 TRANSLATION_API_URL=http://libretranslate:5000
 TRANSLATION_API_KEY=
+
+# -----------------------------------------------------------------------------
+# Contact form anti-spam
+# -----------------------------------------------------------------------------
+# reCAPTCHA v3. When RECAPTCHA_SECRET_KEY is set, the contact form is
+# fail-CLOSED: a valid token with score >= RECAPTCHA_MIN_SCORE is REQUIRED.
+# Leave empty to disable reCAPTCHA (then only rate limit + honeypot apply).
+RECAPTCHA_SITE_KEY=
+RECAPTCHA_SECRET_KEY=
+RECAPTCHA_MIN_SCORE=0.5
+# Per-IP submission limit for the contact form (shared via Redis in prod).
+CONTACT_MAX_PER_HOUR=5
+CONTACT_RATE_WINDOW=3600

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Normalize line endings: store text as LF in the repo and check out LF on all
+# platforms. Prevents the whole tree from showing as modified when edited on
+# Windows (the CRLF churn this repo hit before).
+* text=auto eol=lf
+
+# Shell scripts and Python must stay LF.
+*.sh text eol=lf
+*.py text eol=lf
+
+# Treat these as binary (never touch line endings / never diff as text).
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.svg text eol=lf
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.mo binary

--- a/portfolio/forms/contact.py
+++ b/portfolio/forms/contact.py
@@ -6,6 +6,30 @@ from django.utils.html import escape
 from ..models import Contact
 from .base import HoneypotMixin
 
+# Spam keywords checked in BOTH subject and message. Kept lowercase.
+# Note: this is a best-effort layer — the primary defenses are reCAPTCHA
+# (fail-closed) and per-IP rate limiting in the view.
+SPAM_PATTERNS = [
+    'viagra', 'casino', 'lottery', 'winner', 'congratulations',
+    'click here', 'free money', 'make money fast',
+    'seo service', 'web traffic', 'buy followers', 'crypto',
+    'bitcoin', 'btc', 'forex', 'trading', 'investment opportunity',
+    'withdraw', 'wallet', 'usdt', 'satoshi', 'blockchain',
+    'binance', 'coinbase', 'metamask', 'airdrop', 'seed phrase',
+    'private key', 'marketing agency', 'boost your', 'rank your',
+    'backlink', 'guest post', 'link building',
+]
+
+
+def contains_spam(text):
+    """Return the first spam pattern found in ``text`` (lowercased), or None."""
+    lowered = text.lower()
+    for pattern in SPAM_PATTERNS:
+        if pattern in lowered:
+            return pattern
+    return None
+
+
 class SecureContactForm(forms.ModelForm):
     """
     Contact form with enhanced security and validation.
@@ -88,7 +112,11 @@ class SecureContactForm(forms.ModelForm):
         
         # Remove potentially dangerous characters
         subject = escape(subject)
-        
+
+        # Spam patterns frequently arrive in the subject (e.g. crypto scams)
+        if contains_spam(subject):
+            raise ValidationError('El asunto contiene contenido no permitido.')
+
         return subject
     
     def clean_message(self):
@@ -103,23 +131,13 @@ class SecureContactForm(forms.ModelForm):
         
         # Remove potentially dangerous characters
         message = escape(message)
-        
-        # Check for spam patterns
-        spam_patterns = [
-            'viagra', 'casino', 'lottery', 'winner', 'congratulations',
-            'click here', 'free money', 'make money fast',
-            'seo service', 'web traffic', 'buy followers', 'crypto',
-            'bitcoin', 'forex', 'trading', 'investment opportunity',
-            'marketing agency', 'boost your', 'rank your',
-            'backlink', 'guest post', 'link building',
-        ]
-        message_lower = message.lower()
-        for pattern in spam_patterns:
-            if pattern in message_lower:
-                raise ValidationError('El mensaje contiene contenido no permitido.')
+
+        # Check for spam patterns (shared list, also applied to the subject)
+        if contains_spam(message):
+            raise ValidationError('El mensaje contiene contenido no permitido.')
 
         # Block messages with too many URLs (likely spam)
-        url_count = len(re.findall(r'https?://', message_lower))
+        url_count = len(re.findall(r'https?://', message.lower()))
         if url_count > 2:
             raise ValidationError('Too many links in the message.')
 
@@ -139,6 +157,9 @@ class SecureContactFormWithHoneypot(SecureContactForm):
             'autocomplete': 'off'
         })
     )
+    # Hidden timestamp of when the page was rendered. The template fills it with
+    # {% now "U" %}; a submission faster than 3s is almost certainly a bot.
+    form_loaded_at = forms.CharField(required=False, widget=forms.HiddenInput())
 
     def clean(self):
         cleaned_data = super().clean()

--- a/portfolio/tests/test_contact_spam.py
+++ b/portfolio/tests/test_contact_spam.py
@@ -1,0 +1,132 @@
+"""
+Anti-spam regression tests for the contact form.
+
+These cover the holes that let a bot flood the inbox and relay scam
+"confirmation" emails to third parties:
+
+* reCAPTCHA was fail-open (skipped when no token was sent)
+* the per-IP rate limit was disabled / never matched the form endpoint
+* the auto-confirmation email was sent to attacker-supplied addresses
+* the spam keyword filter ignored the subject and missed "btc"
+* the honeypot timing check was dead code (field was never declared)
+"""
+import time
+from unittest import mock
+
+from django.core import mail
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from portfolio.forms.contact import SecureContactFormWithHoneypot
+from portfolio.models import Contact, Profile
+
+VALID = {
+    'name': 'John Doe',
+    'email': 'john@example.com',
+    'subject': 'Project collaboration',
+    'message': 'I would like to discuss a potential project with you.',
+}
+
+
+def _fake_recaptcha(success=True, score=0.9, action='contact'):
+    """Patch target for urllib.request.urlopen returning a reCAPTCHA verdict."""
+    import json
+
+    payload = {'success': success, 'score': score, 'action': action}
+
+    class _Resp:
+        def read(self):
+            return json.dumps(payload).encode()
+
+    return mock.Mock(return_value=_Resp())
+
+
+class ContactFormValidationTests(TestCase):
+    """Form-level filters (Fix 4 + Fix 5)."""
+
+    def test_subject_spam_rejected(self):
+        data = {**VALID, 'subject': 'URGENT! WITHDRAW 1.3426 BTC NOW'}
+        form = SecureContactFormWithHoneypot(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('subject', form.errors)
+
+    def test_btc_keyword_in_subject_rejected(self):
+        # Regression: 'btc' was missing from the keyword list before.
+        data = {**VALID, 'subject': 'your 1.3426 btc is ready to withdraw'}
+        self.assertFalse(SecureContactFormWithHoneypot(data).is_valid())
+
+    def test_message_spam_rejected(self):
+        data = {**VALID, 'message': 'Claim your free bitcoin wallet right now!!!'}
+        self.assertFalse(SecureContactFormWithHoneypot(data).is_valid())
+
+    def test_too_fast_submission_rejected(self):
+        data = {**VALID, 'form_loaded_at': str(time.time())}  # elapsed ~0s
+        self.assertFalse(SecureContactFormWithHoneypot(data).is_valid())
+
+    def test_normal_submission_is_valid(self):
+        data = {**VALID, 'form_loaded_at': str(time.time() - 30)}
+        form = SecureContactFormWithHoneypot(data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+
+@override_settings(
+    EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+    CACHES={'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'test-contact-spam',
+    }},
+)
+class ContactViewSecurityTests(TestCase):
+    """View-level defenses (Fix 1 + Fix 2 + Fix 3)."""
+
+    def setUp(self):
+        cache.clear()
+        self.url = reverse('portfolio:home')
+        Profile.objects.create(email='owner@example.com')
+
+    def _payload(self, **over):
+        data = {**VALID, 'form_loaded_at': str(time.time() - 30), 'honeypot': ''}
+        data.update(over)
+        return data
+
+    @mock.patch.dict('os.environ', {'RECAPTCHA_SECRET_KEY': 'test-secret'})
+    def test_recaptcha_fail_closed_without_token(self):
+        # Bot posts directly without a reCAPTCHA token -> must be rejected.
+        resp = self.client.post(self.url, self._payload())
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(Contact.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+    @mock.patch.dict('os.environ', {'RECAPTCHA_SECRET_KEY': 'test-secret'})
+    def test_recaptcha_low_score_rejected(self):
+        with mock.patch('urllib.request.urlopen', _fake_recaptcha(score=0.1)):
+            resp = self.client.post(self.url, self._payload(**{'g-recaptcha-response': 'tok'}))
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(Contact.objects.count(), 0)
+
+    @mock.patch.dict('os.environ', {'RECAPTCHA_SECRET_KEY': 'test-secret'})
+    def test_recaptcha_valid_token_accepted(self):
+        with mock.patch('urllib.request.urlopen', _fake_recaptcha(score=0.9)):
+            resp = self.client.post(self.url, self._payload(**{'g-recaptcha-response': 'tok'}))
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(Contact.objects.count(), 1)
+
+    @mock.patch.dict('os.environ', {'RECAPTCHA_SECRET_KEY': ''})
+    def test_no_confirmation_email_to_sender(self):
+        # With reCAPTCHA disabled, a valid submission still must NOT email the
+        # sender-supplied address (the relay vector). Only the owner is notified.
+        resp = self.client.post(self.url, self._payload())
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(Contact.objects.count(), 1)
+        recipients = [addr for m in mail.outbox for addr in m.to]
+        self.assertNotIn(VALID['email'], recipients)
+
+    @mock.patch.dict('os.environ', {'RECAPTCHA_SECRET_KEY': '', 'CONTACT_MAX_PER_HOUR': '3'})
+    def test_rate_limit_blocks_flood(self):
+        for _ in range(3):
+            self.client.post(self.url, self._payload())
+        self.assertEqual(Contact.objects.count(), 3)
+        # 4th submission within the window is blocked before any DB write.
+        self.client.post(self.url, self._payload())
+        self.assertEqual(Contact.objects.count(), 3)

--- a/portfolio/tests/test_contact_spam.py
+++ b/portfolio/tests/test_contact_spam.py
@@ -19,7 +19,8 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from portfolio.forms.contact import SecureContactFormWithHoneypot
-from portfolio.models import Contact, Profile
+from portfolio.models import Contact
+from portfolio.tests.test_views_public import create_test_profile
 
 VALID = {
     'name': 'John Doe',
@@ -83,7 +84,8 @@ class ContactViewSecurityTests(TestCase):
     def setUp(self):
         cache.clear()
         self.url = reverse('portfolio:home')
-        Profile.objects.create(email='owner@example.com')
+        # Raw-SQL helper: Profile has legacy NOT NULL columns that .create() trips on.
+        create_test_profile(email='owner@example.com')
 
     def _payload(self, **over):
         data = {**VALID, 'form_loaded_at': str(time.time() - 30), 'honeypot': ''}

--- a/portfolio/views/general.py
+++ b/portfolio/views/general.py
@@ -6,6 +6,7 @@ import urllib.parse
 import json
 from django.conf import settings
 from django.contrib import messages
+from django.core.cache import cache
 from django.core.paginator import Paginator
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render, redirect
@@ -79,41 +80,126 @@ class HomeView(TemplateView):
             ip = request.META.get('REMOTE_ADDR')
         return ip
 
+    def _contact_rate_limited(self, request):
+        """
+        Per-IP rate limit for contact submissions.
+
+        Uses the shared cache (Redis in production) so the counter is shared
+        across gunicorn workers. Counts every POST attempt to the contact
+        endpoint, so floods are stopped before any DB write or email is sent.
+        Returns True when the caller is over the limit.
+        """
+        ip = self.get_client_ip(request) or 'unknown'
+        max_per_window = int(os.environ.get('CONTACT_MAX_PER_HOUR', '5'))
+        window = int(os.environ.get('CONTACT_RATE_WINDOW', '3600'))
+        cache_key = f'contact_rate:{ip}'
+
+        current = cache.get(cache_key, 0)
+        if current >= max_per_window:
+            return True
+
+        # Fixed-window counter: set with TTL on first hit, then increment.
+        if not cache.add(cache_key, 1, window):
+            try:
+                cache.incr(cache_key)
+            except ValueError:
+                # Key expired between get and incr; restart the window.
+                cache.set(cache_key, 1, window)
+        return False
+
+    def _verify_recaptcha(self, request):
+        """
+        Verify reCAPTCHA v3. Fail-CLOSED when a secret key is configured.
+
+        If RECAPTCHA_SECRET_KEY is set, a valid token with a sufficient score
+        and the expected action is REQUIRED: a missing token, a verification
+        error, an unsuccessful result, an action mismatch or a low score all
+        reject the submission. If no secret is configured, reCAPTCHA is skipped
+        (logged loudly) and the other layers (rate limit, honeypot, timing,
+        content filters) apply.
+
+        Returns (ok: bool, reason: str).
+        """
+        secret = os.environ.get('RECAPTCHA_SECRET_KEY', '').strip()
+        if not secret:
+            logger.warning(
+                "RECAPTCHA_SECRET_KEY not configured — contact form is NOT "
+                "protected by reCAPTCHA; relying on rate limit + honeypot."
+            )
+            return True, 'not_configured'
+
+        token = request.POST.get('g-recaptcha-response', '').strip()
+        ip = self.get_client_ip(request)
+        if not token:
+            logger.warning(f"reCAPTCHA token missing from IP {ip}")
+            return False, 'missing_token'
+
+        try:
+            min_score = float(os.environ.get('RECAPTCHA_MIN_SCORE', '0.5'))
+            data = urllib.parse.urlencode({
+                'secret': secret,
+                'response': token,
+                'remoteip': ip,
+            }).encode()
+            req = urllib.request.Request(
+                'https://www.google.com/recaptcha/api/siteverify', data=data
+            )
+            resp = urllib.request.urlopen(req, timeout=5)
+            result = json.loads(resp.read())
+        except Exception as e:
+            # Fail CLOSED: if we cannot verify, reject rather than let it through.
+            logger.error(f"reCAPTCHA verification error from IP {ip}: {e}")
+            return False, 'verify_error'
+
+        if not result.get('success'):
+            logger.warning(
+                f"reCAPTCHA unsuccessful for IP {ip}: {result.get('error-codes')}"
+            )
+            return False, 'unsuccessful'
+
+        action = result.get('action')
+        if action and action != 'contact':
+            logger.warning(f"reCAPTCHA action mismatch ({action}) from IP {ip}")
+            return False, 'action_mismatch'
+
+        score = result.get('score', 0)
+        if score < min_score:
+            logger.warning(f"reCAPTCHA low score {score} from IP {ip}")
+            return False, 'low_score'
+
+        return True, 'ok'
+
     def post(self, request, *args, **kwargs):
+        # Rate limit first: stop floods before any validation, DB write or email.
+        if self._contact_rate_limited(request):
+            logger.warning(
+                f"Contact rate limit exceeded for IP {self.get_client_ip(request)}"
+            )
+            messages.error(
+                request,
+                _('You have sent too many messages. Please try again later.'),
+            )
+            return redirect('portfolio:home')
+
         form = SecureContactFormWithHoneypot(request.POST)
 
         if form.is_valid():
-            # Check honeypot
+            # Check honeypot (hidden field that real users never fill)
             if form.cleaned_data.get('honeypot'):
                 logger.warning(f"Honeypot triggered by IP {self.get_client_ip(request)}")
                 return redirect('portfolio:home')
 
-            # Verify reCAPTCHA v3
-            recaptcha_secret = os.environ.get('RECAPTCHA_SECRET_KEY', '')
-            recaptcha_token = request.POST.get('g-recaptcha-response', '')
-            if recaptcha_secret and recaptcha_token:
-                try:
-                    verify_url = 'https://www.google.com/recaptcha/api/siteverify'
-                    data = urllib.parse.urlencode({
-                        'secret': recaptcha_secret,
-                        'response': recaptcha_token,
-                        'remoteip': self.get_client_ip(request)
-                    }).encode()
-                    req = urllib.request.Request(verify_url, data=data)
-                    resp = urllib.request.urlopen(req, timeout=5)
-                    result = json.loads(resp.read())
-                    if not result.get('success') or result.get('score', 0) < 0.5:
-                        logger.warning(f"reCAPTCHA failed for IP {self.get_client_ip(request)}: score={result.get('score')}")
-                        messages.error(request, _('Verification failed. Please try again.'))
-                        return redirect('portfolio:home')
-                except Exception as e:
-                    logger.error(f"reCAPTCHA verification error: {e}")
+            # Verify reCAPTCHA v3 (fail-closed when configured)
+            recaptcha_ok, _reason = self._verify_recaptcha(request)
+            if not recaptcha_ok:
+                messages.error(request, _('Verification failed. Please try again.'))
+                return redirect('portfolio:home')
 
             name = form.cleaned_data.get('name')
             email = form.cleaned_data.get('email')
             subject = form.cleaned_data.get('subject')
             message = form.cleaned_data.get('message')
-            
+
             try:
                 contact = Contact.objects.create(
                     name=name,
@@ -121,22 +207,24 @@ class HomeView(TemplateView):
                     subject=subject,
                     message=message
                 )
-                
+
                 logger.info(f'Contact form submitted by {contact.email} from IP {self.get_client_ip(request)}')
-                
+
                 notification_sent = EmailService.send_contact_notification(contact, request.META)
-                confirmation_sent = EmailService.send_contact_confirmation(contact)
-                
-                if notification_sent and confirmation_sent:
-                    success_message = _('Thank you for your message! I\'ve sent you a confirmation email and will get back to you soon.')
-                elif notification_sent:
+                # NOTE: the auto-confirmation email to the sender was removed on
+                # purpose. Because the recipient is the address supplied in the
+                # form, spam bots abused it to relay scam "confirmations" to
+                # arbitrary third parties (backscatter / blacklist risk). The
+                # on-page success message below is the user's confirmation.
+
+                if notification_sent:
                     success_message = _('Thank you for your message! I\'ll get back to you soon.')
                 else:
                     success_message = _('Thank you for your message! It has been saved and I\'ll get back to you soon.')
-                
+
                 messages.success(request, success_message)
                 return redirect('portfolio:home')
-                
+
             except Exception as e:
                 logger.error(f'Contact form error: {e}')
                 messages.error(request, _('There was an error processing your message. Please try again.'))
@@ -144,7 +232,7 @@ class HomeView(TemplateView):
             for field, errors in form.errors.items():
                 for error in errors:
                     messages.error(request, f"{field}: {error}")
-        
+
         return self.render_to_response(self.get_context_data(contact_form=form))
 
 

--- a/templates/portfolio/includes/contact_modal.html
+++ b/templates/portfolio/includes/contact_modal.html
@@ -83,6 +83,11 @@
                     <form class="contact-form" method="post" action="{% url 'portfolio:home' %}" id="contactForm">
                         {% csrf_token %}
                         <input type="hidden" name="g-recaptcha-response" id="recaptchaResponse">
+                        <input type="hidden" name="form_loaded_at" value="{% now 'U' %}">
+                        {# Honeypot: hidden off-screen; real users never fill it, bots do. #}
+                        <input type="text" name="honeypot" id="hp_field" tabindex="-1" autocomplete="off"
+                            aria-hidden="true"
+                            style="position:absolute !important;left:-9999px !important;width:1px;height:1px;opacity:0;">
                         <div class="form-row">
                             <div class="form-group">
                                 <label for="contact_name">{% trans "Name" %} *</label>


### PR DESCRIPTION
## Contexto / incidente

El formulario de contacto estaba siendo abusado por bots (estafa de Bitcoin "1.3426 BTC"): cientos de mensajes a la bandeja cada ~10 min, y además se reenviaban correos de "confirmación" con la estafa a las direcciones que ponía el atacante (terceros como víctimas → riesgo de blacklist del dominio). Se detuvo la instancia EC2 para frenar el flood.

## Causa raíz

No fue que el reCAPTCHA "se rompiera": **todas las capas estaban apagadas o fail-open**:

1. **reCAPTCHA fail-open** — solo validaba `if recaptcha_secret and recaptcha_token`. Un POST directo (sin token, porque los bots no ejecutan el JS) **se saltaba la verificación** y se aceptaba. El `except` también dejaba pasar.
2. **Rate limiter desactivado** — `RateLimitMiddleware` estaba comentado, y su detección de ruta (`'contact' in path`) **nunca matcheaba** el formulario (que postea a `/`, no a `/contact`).
3. **Relay de spam** — el correo de confirmación se enviaba a la dirección del remitente (controlada por el atacante).
4. **Filtro de palabras** — solo revisaba el `message`, no el `subject` (donde iba la estafa), y le faltaba `btc`.
5. **Honeypot por tiempo = código muerto** — `form_loaded_at` no era un campo declarado ni se renderizaba; el honeypot oculto tampoco estaba en el HTML.

## Cambios (defensa en profundidad)

- **reCAPTCHA fail-CLOSED**: con `RECAPTCHA_SECRET_KEY` configurada se exige token válido + `action == 'contact'` + score ≥ `RECAPTCHA_MIN_SCORE`; errores de verificación rechazan. Sin clave configurada, se loguea aviso y aplican las demás capas.
- **Rate limit por IP en la vista** (`CONTACT_MAX_PER_HOUR`, compartido vía Redis en prod), aplicado a cada POST antes de tocar BD o enviar correo.
- **Eliminado el correo de confirmación** al remitente (corta el relay). Se mantienen la notificación al dueño y el mensaje de éxito en pantalla.
- **Filtro de spam también en `subject`** + términos cripto (`btc`, `withdraw`, `wallet`, ...).
- **Honeypot temporal real**: campo `form_loaded_at` declarado + renderizado con `{% now "U" %}`, y honeypot oculto añadido al template.
- **`.gitattributes`** (`eol=lf`) para que el árbol no vuelva a ensuciarse con CRLF.
- Variables nuevas documentadas en `.env.example`.

## Tests

Nuevo `portfolio/tests/test_contact_spam.py` (10 casos): reCAPTCHA fail-closed sin token, score bajo, token válido aceptado, sin correo al remitente, rate-limit corta el flood, y filtros de subject/btc/honeypot temporal. Verificados localmente (10/10). Los tests con BD se validan en CI con Postgres.

## Despliegue (importante)

- **No reabrir el formulario al público** (Nginx) hasta desplegar esto.
- Configurar en el `.env` de prod: `RECAPTCHA_SITE_KEY`, `RECAPTCHA_SECRET_KEY` (sin ellas el reCAPTCHA no protege). Ajustar `CONTACT_MAX_PER_HOUR` si hace falta.