### PR TITLE
fix(ci): bust Docker code layer cache in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,8 @@ jobs:
           tags: |
             ${{ steps.image.outputs.name }}:${{ needs.create-release.outputs.version }}
             ${{ steps.image.outputs.name }}:latest
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,14 @@ RUN pip install --upgrade pip \
     && pip install -r requirements/base.txt \
     && if [ -f requirements/development.txt ]; then pip install -r requirements/development.txt; fi
 
+# Cache-bust the code layer per commit. Without this, BuildKit's gha cache can
+# serve a stale `COPY . .` layer and ship an image without the latest code
+# (this is what made a release image miss its own fix). The git SHA changes
+# every commit, so the COPY below (and everything after) is always rebuilt,
+# while the heavy apt/pip layers above stay cached.
+ARG GIT_SHA=dev
+LABEL org.opencontainers.image.revision="${GIT_SHA}"
+
 COPY . .
 
 EXPOSE 8000


### PR DESCRIPTION
## Problema

El release de `v1.3.2` (commit con un fix de seguridad del formulario de contacto) **construyó y publicó una imagen GHCR que NO contenía ese fix**, pese a que el build terminó "con éxito".

Causa raíz (verificada en los logs del build):
- El job de build hizo checkout correcto del commit del tag (`3c17c58`, con el fix).
- Pero con `cache-from/cache-to: type=gha`, la capa **`COPY . .` salió `CACHED`** desde un build previo (v1.3.1, pre-fix).
- Resultado: la imagen `v1.3.2` era esencialmente la de `v1.3.1` recacheada → sin el código nuevo.

(En prod no causó caída porque el contenedor corre con bind-mount del checkout del host, no de la imagen — pero cualquier flujo que use la imagen GHCR recibía código viejo.)

## Fix

`Dockerfile`: un `ARG GIT_SHA` (consumido por un `LABEL`) **justo antes de `COPY . .`**. `release.yml`: se pasa `GIT_SHA=${{ github.sha }}` como `build-arg`.

El SHA cambia en cada commit → invalida la capa `COPY . .` (y las siguientes) en cada build, **garantizando** que la imagen contenga el código del commit construido. Las capas pesadas (apt, pip install) quedan **antes** del ARG, así que **siguen cacheadas** (solo se reconstruyen si cambian los `requirements/`). Se conserva el beneficio de la caché sin el riesgo de código obsoleto.

## Verificación (tras mergear)

Cortar un tag nuevo y confirmar que la imagen trae el código:
\`\`\`
docker run --rm --entrypoint sh ghcr.io/henfrydls/portafolio-manager:<tag> \
  -c "grep -rc _verify_recaptcha /app/portfolio/views/general.py"   # debe ser > 0
\`\`\`