### PR TITLE
feat: sync GitHub stars and forks from the API

### DIFF
--- a/portfolio/management/commands/sync_github_stats.py
+++ b/portfolio/management/commands/sync_github_stats.py
@@ -1,0 +1,146 @@
+"""
+Management command to sync stars, forks and primary language from the GitHub API.
+
+The Project model advertises that stars_count/forks_count update automatically,
+but nothing ever populated them. This command does, and is meant to run on a cron.
+
+Private projects are skipped on purpose: their counters are manual estimates.
+"""
+
+import os
+import re
+from urllib.parse import urlparse
+
+import requests
+from django.core.management.base import BaseCommand
+
+from portfolio.models import Project
+
+GITHUB_API = 'https://api.github.com/repos/{owner}/{repo}'
+# Takes the first two path segments, so deep links like /owner/repo/tree/main work too.
+REPO_PATH_RE = re.compile(r'^/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?(?:/.*)?$')
+
+
+class Command(BaseCommand):
+    help = 'Sync stars, forks and primary language for public GitHub projects'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Show what would change without writing to the database'
+        )
+        parser.add_argument(
+            '--timeout',
+            type=int,
+            default=10,
+            help='Per-request timeout in seconds (default: 10)'
+        )
+        parser.add_argument(
+            '--slug',
+            help='Sync a single project by slug instead of all of them'
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        timeout = options['timeout']
+
+        projects = Project.objects.exclude(github_url='').filter(is_private_project=False)
+        if options['slug']:
+            projects = projects.filter(slug=options['slug'])
+        projects = projects.order_by('id')
+
+        if not projects.exists():
+            self.stdout.write(self.style.WARNING('No public projects with a GitHub URL found.'))
+            return
+
+        session = requests.Session()
+        session.headers.update({
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'henfrydls-portfolio-sync',
+        })
+        token = os.environ.get('GITHUB_TOKEN', '').strip()
+        if token:
+            session.headers['Authorization'] = f'Bearer {token}'
+
+        updated = unchanged = failed = 0
+
+        for project in projects:
+            name = str(project)
+            repo_id = self._parse_repo(project.github_url)
+            if not repo_id:
+                self.stdout.write(self.style.WARNING(
+                    f'  ! {name}: cannot parse a repo out of {project.github_url}'
+                ))
+                failed += 1
+                continue
+
+            owner, repo = repo_id
+            try:
+                response = session.get(
+                    GITHUB_API.format(owner=owner, repo=repo), timeout=timeout
+                )
+            except requests.RequestException as exc:
+                self.stdout.write(self.style.ERROR(f'  ! {name}: request failed ({exc})'))
+                failed += 1
+                continue
+
+            if response.status_code != 200:
+                detail = response.json().get('message', '') if response.content else ''
+                self.stdout.write(self.style.ERROR(
+                    f'  ! {name}: GitHub returned {response.status_code} {detail}'.rstrip()
+                ))
+                failed += 1
+                continue
+
+            data = response.json()
+            changes = {}
+
+            stars = data.get('stargazers_count', 0)
+            if stars != project.stars_count:
+                changes['stars_count'] = stars
+
+            forks = data.get('forks_count', 0)
+            if forks != project.forks_count:
+                changes['forks_count'] = forks
+
+            # Only fill these in when empty; a human may have set them deliberately.
+            if not project.github_owner:
+                changes['github_owner'] = data.get('owner', {}).get('login', owner)
+            if not project.primary_language and data.get('language'):
+                changes['primary_language'] = data['language']
+
+            if not changes:
+                unchanged += 1
+                self.stdout.write(f'  = {name}: {stars} stars, {forks} forks')
+                continue
+
+            summary = ', '.join(
+                f'{field} {getattr(project, field)!r} -> {value!r}'
+                for field, value in changes.items()
+            )
+            if dry_run:
+                self.stdout.write(self.style.WARNING(f'  ~ {name}: would set {summary}'))
+            else:
+                # .update() on purpose: Project.save() re-optimizes the image file on
+                # every call, so a scheduled save() would slowly degrade it.
+                Project.objects.filter(pk=project.pk).update(**changes)
+                self.stdout.write(self.style.SUCCESS(f'  * {name}: {summary}'))
+            updated += 1
+
+        prefix = 'DRY RUN: ' if dry_run else ''
+        line = f'{prefix}{updated} updated, {unchanged} already current, {failed} failed'
+        style = self.style.ERROR if failed else self.style.SUCCESS
+        self.stdout.write(style(line))
+
+    @staticmethod
+    def _parse_repo(url):
+        """Return (owner, repo) for a github.com URL, or None."""
+        parsed = urlparse(url)
+        if parsed.netloc.lower() not in ('github.com', 'www.github.com'):
+            return None
+        match = REPO_PATH_RE.match(parsed.path)
+        if not match:
+            return None
+        return match.group('owner'), match.group('repo')

--- a/portfolio/tests/test_sync_github_stats.py
+++ b/portfolio/tests/test_sync_github_stats.py
@@ -1,0 +1,179 @@
+"""
+Tests for the sync_github_stats management command.
+
+Every GitHub call is mocked; these tests never touch the network.
+"""
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from portfolio.management.commands.sync_github_stats import Command
+from portfolio.models import Project
+
+
+def make_project(title, **fields):
+    project = Project()
+    project.set_current_language('en')
+    project.title = title
+    project.description = f'{title} description'
+    for field, value in fields.items():
+        setattr(project, field, value)
+    project.save()
+    return project
+
+
+class FakeResponse:
+    """Minimal stand-in for requests.Response."""
+
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.content = b'{}'
+
+    def json(self):
+        return self._payload
+
+
+def repo_payload(stars=0, forks=0, language='Python', owner='henfrydls'):
+    return {
+        'stargazers_count': stars,
+        'forks_count': forks,
+        'language': language,
+        'owner': {'login': owner},
+    }
+
+
+class ParseRepoTest(TestCase):
+    """The URL parser is what decides which repo gets queried."""
+
+    def test_parses_plain_repo_url(self):
+        self.assertEqual(
+            Command._parse_repo('https://github.com/henfrydls/Skima'),
+            ('henfrydls', 'Skima')
+        )
+
+    def test_tolerates_trailing_slash_git_suffix_and_www(self):
+        for url in (
+            'https://github.com/henfrydls/daylo/',
+            'https://github.com/henfrydls/daylo.git',
+            'https://www.github.com/henfrydls/daylo',
+        ):
+            with self.subTest(url=url):
+                self.assertEqual(Command._parse_repo(url), ('henfrydls', 'daylo'))
+
+    def test_parses_deep_link(self):
+        self.assertEqual(
+            Command._parse_repo('https://github.com/henfrydls/daylo/tree/main'),
+            ('henfrydls', 'daylo')
+        )
+
+    def test_rejects_non_repo_urls(self):
+        for url in (
+            'https://github.com/henfrydls',
+            'https://github.com/',
+            'https://gitlab.com/henfrydls/daylo',
+            '',
+        ):
+            with self.subTest(url=url):
+                self.assertIsNone(Command._parse_repo(url))
+
+
+class SyncGithubStatsCommandTest(TestCase):
+
+    def run_command(self, payload=None, status_code=200, **options):
+        response = FakeResponse(payload or repo_payload(), status_code)
+        with patch('requests.Session.get', return_value=response) as mocked:
+            out = StringIO()
+            call_command('sync_github_stats', stdout=out, **options)
+        return out.getvalue(), mocked
+
+    def test_updates_stars_and_forks(self):
+        project = make_project('Skima', github_url='https://github.com/henfrydls/Skima')
+
+        self.run_command(repo_payload(stars=3, forks=1))
+
+        project.refresh_from_db()
+        self.assertEqual(project.stars_count, 3)
+        self.assertEqual(project.forks_count, 1)
+
+    def test_dry_run_leaves_database_untouched(self):
+        project = make_project(
+            'Skima', github_url='https://github.com/henfrydls/Skima', stars_count=0
+        )
+
+        output, _ = self.run_command(repo_payload(stars=3), dry_run=True)
+
+        project.refresh_from_db()
+        self.assertEqual(project.stars_count, 0)
+        self.assertIn('DRY RUN', output)
+
+    def test_skips_private_projects(self):
+        make_project(
+            'Internal tool',
+            github_url='https://github.com/henfrydls/internal',
+            is_private_project=True,
+            stars_count=7,
+        )
+
+        output, mocked = self.run_command(repo_payload(stars=99))
+
+        mocked.assert_not_called()
+        self.assertIn('No public projects', output)
+
+    def test_does_not_overwrite_an_existing_primary_language(self):
+        project = make_project(
+            'Portfolio Manager',
+            github_url='https://github.com/henfrydls/Portafolio-Manager',
+            primary_language='python',
+        )
+
+        self.run_command(repo_payload(language='Python'))
+
+        project.refresh_from_db()
+        self.assertEqual(project.primary_language, 'python')
+
+    def test_fills_blank_owner_and_language(self):
+        project = make_project(
+            'Daylo', github_url='https://github.com/henfrydls/daylo'
+        )
+
+        self.run_command(repo_payload(language='TypeScript', owner='henfrydls'))
+
+        project.refresh_from_db()
+        self.assertEqual(project.github_owner, 'henfrydls')
+        self.assertEqual(project.primary_language, 'TypeScript')
+
+    def test_reports_failure_without_touching_counters(self):
+        project = make_project(
+            'Gone', github_url='https://github.com/henfrydls/gone', stars_count=5
+        )
+
+        output, _ = self.run_command({'message': 'Not Found'}, status_code=404)
+
+        project.refresh_from_db()
+        self.assertEqual(project.stars_count, 5)
+        self.assertIn('1 failed', output)
+
+    def test_unparseable_url_is_reported_and_not_requested(self):
+        make_project('Broken', github_url='https://example.com/not-a-repo')
+
+        output, mocked = self.run_command()
+
+        mocked.assert_not_called()
+        self.assertIn('1 failed', output)
+
+    def test_second_run_reports_nothing_to_change(self):
+        make_project(
+            'Skima',
+            github_url='https://github.com/henfrydls/Skima',
+            github_owner='henfrydls',
+            primary_language='JavaScript',
+        )
+        payload = repo_payload(stars=3, forks=1, language='JavaScript')
+
+        self.run_command(payload)
+        output, _ = self.run_command(payload)
+
+        self.assertIn('0 updated, 1 already current, 0 failed', output)


### PR DESCRIPTION
## Problem

`Project.stars_count` and `Project.forks_count` carry the help text *"se actualiza automaticamente"*, but nothing in the codebase ever wrote to them. There is no management command, no task, and no API call anywhere outside the translation service. The counters simply held whatever was last typed into the admin, so the badges on the home page drifted away from reality.

## Solution

A `sync_github_stats` management command that reads the public GitHub API for every project that has a `github_url`, and writes back the current counts. Intended to run on a schedule.

```
python manage.py sync_github_stats            # sync everything
python manage.py sync_github_stats --dry-run  # preview
python manage.py sync_github_stats --slug foo # a single project
```

## Design decisions

**Writes use `queryset.update()`, not `save()`.** `Project.save()` calls `optimize_uploaded_image` on every invocation, so a scheduled `save()` would recompress the project image on each run and degrade it over time. `.update()` touches only the counter columns.

**Private projects are skipped.** The field help text says private projects may carry a manually estimated number, so overwriting them with a GitHub lookup would be wrong (and the lookup would fail anyway).

**Fields a human may have set are only filled when blank.** `github_owner` and `primary_language` are populated when empty and left alone otherwise, so a deliberate value like a lowercase `python` survives.

**Failures are per project and non-destructive.** A 404, a rate limit, a timeout, or an unparseable URL is reported on its own line and the existing counters stay untouched. The command reads `GITHUB_TOKEN` from the environment when present; the unauthenticated limit is plenty for a portfolio-sized repo list.

## Tests

12 new tests in `portfolio/tests/test_sync_github_stats.py`, all network calls mocked. They cover URL parsing (trailing slashes, `.git`, `www.`, deep links, and rejection of non-repo and non-GitHub URLs), the counter update, `--dry-run` leaving the database alone, private projects being skipped, blank-only backfill of owner and language, a 404 not clobbering counts, and idempotency on a second run.

## Notes

No schema change and no migration. No existing file is modified; the change is two new files.