### PR TITLE
chore(deps): bump Pillow and Django to security-patched versions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-Django==5.2.15
-Pillow==12.2.0
+Django==5.2.16
+Pillow==12.3.0
 whitenoise==6.12.0
 python-decouple==3.8
 python-dotenv==1.2.2


### PR DESCRIPTION
Bumps the two dependencies flagged by the repository's open security alerts:

- **Pillow 12.2.0 → 12.3.0** — resolves the open high-severity advisories (all flag `< 12.3.0`).
- **Django 5.2.15 → 5.2.16** — resolves the open moderate/low advisories (all flag `< 5.2.16`).

Validated locally against current `main`: full test suite (126 passed) on a fresh virtualenv with these exact pins, `pip check` clean. The only warning in the run is Django's pre-existing `RemovedInDjango60Warning` about `forms.URLField`'s future default scheme, unrelated to these bumps.

Supersedes the remaining version gap left after #110.
