### PR TITLE
chore: align project version with the v1.4.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "henfrydls-portfolio"
-version = "1.0.0"
+version = "1.4.0"
 description = "Professional Django portfolio website with multilingual support"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps the long-stale `pyproject.toml` version (stuck at 1.0.0 since the beginning; the release workflow tags independently) to match the upcoming v1.4.0 release.

Release contents already on main: GitHub stats sync (#113), configurable subscribe CTA (#118), UUID image filenames (#121), security dependency bumps (#122), Umami analytics phase 1 (#123).